### PR TITLE
Adds warning for missing project name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Then:
 
 If your version of curl does not support sftp and you wish to use the tools in this repository to deploy, you will have to use a version of curl that does support it. For OSX users, the verification script used brew to take care of that problem. For users of other operating systems, check your online support communities. 
 
-Now edit the `fabfile.py` and adjust the settings for your project.
+Now edit the `fabfile.py` and adjust the settings for your project. Many commands will not work if the project does not have a name.
 
 ## Usage
 

--- a/fablib/wordpress/__init__.py
+++ b/fablib/wordpress/__init__.py
@@ -61,7 +61,13 @@ def verify_prerequisites():
             local('brew install git-ftp')
         else:
             print(colors.green('You have git-ftp installed!'))
-
+            
+        print(colors.cyan('Making sure that the project name is set'))
+        if env.project_name == '':
+            print(colors.red('Your project name has not been set.\nConfigure your project in fabfile.py'))
+        else:
+            print(colors.green('Project name is: ' + env.project_name))
+        
         print(colors.green('Your system is ready to deploy code!'))
 
 


### PR DESCRIPTION
If the project is not named, running `fab verify_prerequisites` will notify the user of an error, to prevent things like #4 from happening. 
