### PR TITLE
Better error handling

### DIFF
--- a/fablib/__init__.py
+++ b/fablib/__init__.py
@@ -19,7 +19,6 @@ from helpers import capture
 env.path = ''
 env.dry_run = False
 env.verbose = False
-env.fabfilepath = os.path.dirname(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
 
 
 @task

--- a/fablib/__init__.py
+++ b/fablib/__init__.py
@@ -3,6 +3,7 @@ import os
 from fabric.api import require, settings, task
 from fabric.state import env
 from fabric import colors, context_managers
+from fabric.main import find_fabfile
 
 # Other fabfiles
 import local
@@ -92,7 +93,7 @@ def deploy():
     Deploy local copy of repository to target environment.
     """
     require('branch', provided_by=[master, stable, branch, ])
-    with context_managers.lcd(env.fabfilepath): # Allows you to run deploy from any child directory of the project
+    with context_managers.lcd(os.path.dirname(find_fabfile())): # Allows you to run deploy from any child directory of the project
         ret = wp.deploy()
 
     if ret.return_code and ret.return_code > 0:

--- a/fablib/__init__.py
+++ b/fablib/__init__.py
@@ -91,5 +91,9 @@ def deploy():
     Deploy local copy of repository to target environment.
     """
     require('branch', provided_by=[master, stable, branch, ])
-    wp.deploy()
-    notify_hipchat()
+    ret = wp.deploy()
+    if ret.return_code and ret.return_code > 0:
+        if ret.return_code in [4, ]:
+            print(colors.red("Try running ") + colors.white("fab wp.verify_prerequisites"))
+    else:
+        notify_hipchat()

--- a/fablib/__init__.py
+++ b/fablib/__init__.py
@@ -2,7 +2,7 @@ import os
 
 from fabric.api import require, settings, task
 from fabric.state import env
-from fabric import colors
+from fabric import colors, context_managers
 
 # Other fabfiles
 import local
@@ -18,6 +18,7 @@ from helpers import capture
 env.path = ''
 env.dry_run = False
 env.verbose = False
+env.fabfilepath = os.path.dirname(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
 
 
 @task
@@ -91,7 +92,9 @@ def deploy():
     Deploy local copy of repository to target environment.
     """
     require('branch', provided_by=[master, stable, branch, ])
-    ret = wp.deploy()
+    with context_managers.lcd(env.fabfilepath): # Allows you to run deploy from any child directory of the project
+        ret = wp.deploy()
+
     if ret.return_code and ret.return_code > 0:
         if ret.return_code in [4, ]:
             print(colors.red("Try running ") + colors.white("fab wp.verify_prerequisites"))

--- a/fablib/wp/__init__.py
+++ b/fablib/wp/__init__.py
@@ -116,6 +116,7 @@ def deploy():
                     print(colors.red("An error occurred..."))
                     if not env.verbose:
                         print(colors.yellow('Try deploying with `verbose` for more information...'))
+    return ret
 
 
 def initial_deploy(dest_path):


### PR DESCRIPTION
Deploys can now be run from directories other than the root directory.

If the deploy upload fails, the script suggests to run `fab wp.verify_prerequisites` and does not notify Hipchat.

This resolves #15 and #14