### PR TITLE
Adding php5-curl to the packages installed when vagrant is provisioned

### DIFF
--- a/vagrant/boot-script.sh
+++ b/vagrant/boot-script.sh
@@ -52,7 +52,7 @@ debconf-set-selections <<< "mysql-server mysql-server/root_password_again passwo
 
 install_pkg apache2 mysql-server libapache2-mod-auth-mysql \
     php5-mysql php5 libapache2-mod-php5 php5-mcrypt php5-memcache \
-    php5-gd
+    php5-gd php5-curl
 
 # Install memcached php extension
 yes '' | pecl install memcached


### PR DESCRIPTION
To install this package on your current vagrant box:

```
sudo apt-get update
sudo apt-get install php5-curl
```

And then restart apache2:

```
sudo /etc/init.d/apache2 restart 
```

OR 

```
 sudo service apache2 restart
```
