### PR TITLE
Removing brew install git-ftp, point people to the git-ftp install instructions

### DIFF
--- a/fablib/wp/__init__.py
+++ b/fablib/wp/__init__.py
@@ -42,9 +42,7 @@ def verify_prerequisites():
         ret = capture('git ftp --version')
         if ret.return_code == 1:
             print(colors.yellow(
-                'You do not have git-ftp installed. Attempting installation via brew...'))
-            capture('brew update')
-            capture('brew install git-ftp')
+                'You do not have git-ftp installed. Install version 0.9.0 using these instructions: https://github.com/git-ftp/git-ftp/blob/develop/INSTALL.md'))
         else:
             print(colors.green('You have git-ftp installed!'))
 


### PR DESCRIPTION
Because brew installs the latest version, and the latest version appears to have problems with WPEngine. 
### Changes:
- `brew install git-ftp` is removed.
- Error message now points people to the git-ftp install instructions here: https://github.com/git-ftp/git-ftp/blob/develop/INSTALL.md
