### PR TITLE
Throw errors when something goes wrong with wp.install

### DIFF
--- a/fablib/wp/__init__.py
+++ b/fablib/wp/__init__.py
@@ -66,27 +66,26 @@ def verify_prerequisites():
 
 
 @task
-def install(tag):
+def install(tag='master'):
     """
     Downloads specified version of WordPress from https://github.com/WordPress/WordPress and
     installs it.
     """
-    with settings(warn_only=True):
-        try:
-            print(colors.cyan('Downloading WordPress %s' % tag))
-            capture('curl -L -O "https://github.com/WordPress/WordPress/archive/%s.zip"' % tag)
+    try:
+        print(colors.cyan('Downloading WordPress %s' % tag))
+        capture('curl -f -L -O "https://github.com/WordPress/WordPress/archive/%s.zip"' % tag)
 
-            print(colors.cyan('Unzipping...'))
-            capture('unzip %s.zip' % tag)
+        print(colors.cyan('Unzipping...'))
+        capture('unzip %s.zip' % tag)
 
-            print(colors.cyan('Copying new files to our project directory...'))
-            capture('rsync -ru WordPress-%s/* .' % tag)
-        finally:
-            print(colors.cyan('Cleaning up...'))
-            capture('rm -Rf %s.zip' % tag)
-            capture('rm -Rf WordPress-%s' % tag)
+        print(colors.cyan('Copying new files to our project directory...'))
+        capture('rsync -ru WordPress-%s/* .' % tag)
+    finally:
+        print(colors.cyan('Cleaning up...'))
+        capture('rm -Rf %s.zip' % tag)
+        capture('rm -Rf WordPress-%s' % tag)
 
-        print(colors.cyan('Finished upgrading WordPress!'))
+    print(colors.cyan('Finished upgrading WordPress!'))
 
 
 @task


### PR DESCRIPTION
See #26.

This PR:

- Removes `with settings(warn_only=True)` which means if any part of the task fails, fabric will now exit and show an error message.
- Adds the `-f` flag to the call to `curl` which allows curl to return an exit code >= 1 when the HTTP response code is >= 400. So, if there is no archive for a given tag, fabric will raise an error.