### PR TITLE
Ability to use PHP's built-in web server for local development

### DIFF
--- a/fablib/wp/__init__.py
+++ b/fablib/wp/__init__.py
@@ -20,6 +20,7 @@ __all__ = [
     'install',
     'fetch_sql_dump',
     'deployed_commit',
+    'runserver',
     'cmd',
     'maintenance',
     'tests',

--- a/lib/router.php
+++ b/lib/router.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * WordPress router for use with PHP built-in web server
+ *
+ * @see https://gist.github.com/tamagokun/3801087
+ */
+$root = $_SERVER['DOCUMENT_ROOT'];
+chdir( $root );
+$path = '/' . ltrim( parse_url( $_SERVER['REQUEST_URI'] )['path'], '/' );
+set_include_path( get_include_path() . ':' . __DIR__ );
+
+if ( file_exists($root.$path) ) {
+	if( is_dir( $root.$path ) && substr( $path, strlen( $path ) - 1, 1 ) !== '/' ) {
+		$path = rtrim( $path, '/' ) . '/index.php';
+	}
+
+	if( strpos( $path, '.php' ) === false ) {
+		return false;
+	} else {
+		chdir( dirname( $root . $path ) );
+		require_once $root . $path;
+	}
+} else {
+	include_once 'index.php';
+}


### PR DESCRIPTION
This adds a `wp.runserver` command, which uses PHP's built-in web server to run the project for local development.

Notes:
- Requires PHP version 5.4 or greater
- Uses sudo since WordPress can not run on any port other than 80
- Uses lib/router.php as a substitute for .htaccess with PHP web server
- Sets error_log to `STDERR` so that errors appear in the same shell the server was started in
