### PR TITLE
Remove double quotes from the path of the Virtualbox private key

### DIFF
--- a/fablib/__init__.py
+++ b/fablib/__init__.py
@@ -83,7 +83,11 @@ def dev():
     env.hosts = [env.vagrant_host, ]
     env.path = '/vagrant'
     result = capture('vagrant ssh-config | grep IdentityFile')
-    env.key_filename = result.split()[1]
+    result = result.split()[1]
+    if result.startswith('"') and result.endswith('"'):
+        result = result[1:-1]
+
+    env.key_filename = result
 
 
 @task


### PR DESCRIPTION
## Changes

If the path to the Vagrant private key is wrapped in `""`, this PR removes the `""` so that the key's filename works with the rest of the deploy tools and Fabric code.


## Why

For #39.

~~This doesn't attempt to find a reason why the `""` were added. It just removes them if they exist.~~ The `""` were added in a recent update to Vagrant, as documented in #39. This will eventually affect every user.