### PR TITLE
Split a lot of docs out of README.md into the docs/ folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,55 +24,11 @@ Open a new terminal window or tab and create a virtual environment for your proj
 
 ## Setup
 
-To use these tools, add this repo as a git submodule in the root of your project:
+If you're creating an INN-style umbrella repository for a Wordpress site or multisite, these tools are already included in [the umbrella boilerplate](https://github.com/INN/umbrella-boilerplate/blob/master/docs/README.md).
 
-	$ git submodule add https://github.com/INN/deploy-tools.git tools
-
-Then pull the example files in to the root of your project:
-
-	$ cp -Rf tools/examples/* ./
-
-Install the required libraries with pip:
-
-Note: if you're using OS X Mavericks (10.9), you might need to set some compiler flags for Fabric and its dependencies to install correctly:
-
-    $ export CFLAGS=-Qunused-arguments
-    $ export CPPFLAGS=-Qunused-arguments
-
-Then:
-
-    $ workon projectnamegoeshere
-    $ pip install -r requirements.txt
-    $ fab wp.verify_prerequisites
-
-The `wp.verify_prerequisites` command will notify you of any issues that might prevent you from using the deploy tools in their entirety.
-
-Now edit the example `fabfile.py` to adjust the settings for your project:
-
-    env.project_name = ''   # name for the project
-
-You'll also want to supply the ssh environment variables for `production` and `staging` (or any other enviornments).
-
-    env.hosts       = []    # ssh host for production.
-    env.user        = ''    # ssh user for production.
-    env.password    = ''    # ssh password for production.
-
-    env.hosts       = []    # ssh host for staging.
-    env.user        = ''    # ssh user for staging.
-    env.password    = ''    # ssh password for staging.
-
-By default, the deploy tools will use git for deployment to WP Engine. If you'd rather use sftp to deploy, you can do so by specifying `sftp_deploy` in your `fabfile.py`.
-
-    env.sftp_deploy = True
-
-After setting `env.sftp_deploy` to `True`, make sure you run `wp.verify_prerequisites` to ensure you have the required software installed.
-
-If your version of curl does not support sftp and you wish to use the tools in this repository to deploy, you will have to use a version of curl that does support it. For OSX users, the verification script uses brew to take care of that problem. For users of other operating systems, check your online support communities. Ubuntu users may have success in following [this guide](http://zeroset.mnim.org/2013/03/14/sftp-support-for-curl-in-ubuntu-12-10-quantal-quetzal-and-later/).
-
+If you're doing something else, read [the setup docs](docs/using-in-your-project.md).
 
 ## Usage
-
-### Deployment
 
 These tools use [Fabric](http://www.fabfile.org/).
 
@@ -80,42 +36,23 @@ To see a list of available commands:
 
     $ fab -l
 
-To deploy to your staging environment:
+Commands are documented in [COMMANDS.md](COMMANDS.md)
 
-    $ fab staging master deploy
+### Deployment
 
-And production:
+See [docs/deploy.md](docs/deploy.md)
 
-    $ fab production master deploy
-
-To switch to a different branch and deploy
-
-    $ fab staging branch:newfeaturebranchname deploy
+A very long walk-through: https://gist.github.com/benlk/b75600e7243ac69f6e4275b65ba62d91
 
 ### Local development
 
-#### The Basics
+If you want your own VM for development work, check out [docs/vagrant.md](docs/vagrant.md).
 
-The examples directory also includes a `Vagrantfile`, a bunch of config files for Apache, PHP, MySQL and a `boot-script.sh` for provisioning a Vagrant instance for local development.
+You can also use [Varying Vagrant Vagrants](https://github.com/Varying-Vagrant-Vagrants/VVV) with [vv](https://github.com/bradp/vv); INN umbrella repositories based off of [INN/umbrella-boilerplate](https://github.com/INN/umbrella-boilerplate) use that combination.
 
-Assuming you have [VirtualBox](https://www.virtualbox.org/wiki/Downloads) and [Vagrant](http://www.vagrantup.com/downloads) installed, and enough spare disk space, start the Vagrant box with:
+You can use Laravel Valet as well; the only difference is that you'll need to replace `vagrant` or `dev` commands with `local` ones. See [the list of commands](COMMANDS.md).
 
-    $ vagrant up
-
-It should take about ten minutes to complete the provisioning process, depending on your internet connection speed. 
-
-When the Vagrant box is ready, you'll want to edit your `/etc/hosts` file (i.e. not the `hosts` file on the Vagrant box), adding:
-
-    192.168.33.10 vagrant.dev
-
-Once you've done that, you should be able to visit [http://vagrant.dev](http://vagrant.dev) and see your project running.
-
-A couple notes:
-
-- The Apache configuration for our Vagrant box uses the root directory of your project as the www root for vagrant.dev.
-- Our provisioning script installs mysql and sets a password for the root user with value 'root'.
-
-#### Database commands
+### Database commands
 
 These tools include a few commands to ease database setup and manipulation. [Read about them here](https://github.com/INN/deploy-tools/blob/master/COMMANDS.md).
 
@@ -123,9 +60,9 @@ These tools include a few commands to ease database setup and manipulation. [Rea
 
 In setting up your dev environment, you'll want to pull in all the necessary WordPress files if they are not included in the project repository. To do this, use the command:
 
-    $ fab wp.install:"3.9.1"
+    $ fab wp.install:"4.8.1"
 
-Where "3.9.1" identifies the [tagged version of the WordPress repository](https://github.com/WordPress/WordPress/tags) that you want to use.
+Where "4.8.1" identifies the [tagged version of the WordPress repository](https://github.com/WordPress/WordPress/tags) that you want to use.
 
 Fabric will download the release .zip file from Github and extract its contents to the project root.
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,0 +1,91 @@
+# Deployment processes
+
+For a reference of command meanings, see [COMMANDS.md](../COMMANDS.md)
+
+Before running any deploy, you'll need to make sure:
+
+- your current working directory in the terminal is in the umbrella repository
+- your umbrella is configured with secrets, and the secrets are up-to-date
+- you ahve run `workon largo` or its equivalent to load the virtualenv you use with the deploy tools
+
+Here's a table of contents of this page:
+
+- Normal Deploy
+- Deploy a site for the first time via SFTP
+- Deploy fails with "failed to resolve ... as a valid commit"
+- Deploying to a site that has been edited outside of version control
+
+
+## Simple deploy
+
+Let's test-deploy the 'staging' branch to the staging environment. This doesn't upload anything, but just makes sure that everything can be uploaded.
+
+	fab staging branch:staging dry_run deploy
+
+That should come out without any warnings or errors. Time to deploy to staging for real:
+
+	fab staging branch:staging deploy
+
+Of course, if you wanted to deploy the master branch to production, you'd do this:
+
+	fab staging branch:master deploy
+
+Or, to save a few keystrokes, there's the `master` alias, which runs `branch:master`:
+
+	fab staging master deploy
+
+When it comes time to deploy to production:
+
+	fab production master dry_run deploy
+	fab production master deploy
+
+## Deploy a site for the first time via SFTP
+
+```
+curl: (78) Could not open remote file for reading: No such file or directory
+```
+
+This error is caused by the directories occupied by submodules not existing on the remote server. Until [#52](https://github.com/INN/deploy-tools/issues/52) is fixed, the initial deploy must be done by hand.
+
+To deploy over SFTP by hand:
+
+1. Using the hostname, username, and password referenced in your project's `fabfile.py`, connect to the server via SFTP using an SFTP client such as FileZilla or Cyberduck.
+2. From your local copy of the repository, copy the directories containing any git submodules into their appropriate parent directories on the server.
+3. Try running a deploy using `fab`, and make a note of any errors occur.
+
+## Deploy fails with "failed to resolve ... as a valid commit"
+
+```
+fatal: Failed to resolve 'foo' as a valid ref.
+fatal: Failed to resolve '6062fde88cbd1823be1fa7d0d1ef6cc8e1e6a0ef' as a valid ref.
+```
+
+When deploying, the `deploy` task makes a note of the commit that is currenly deployed on the remote server and tags that commit with the `rollback` tag. (See [git tag](https://git-scm.com/book/en/v2/Git-Basics-Tagging))
+
+If the commit hash saved in the `.git-ftp.log` file on the server is not available in the local copy of the repository, then you will see this error.
+
+First, run `git pull` to make sure that you have all commits from the upstream version of this repository. You may need to resolve merge conflicts if there are commits upstream that did not exist locally.
+
+If the commit hash from `.git-ftp.log` is not in any repository you have access to, well, it looks like someone deployed without pushing. Ask everyone to push their work, please.
+
+If no one has the work in question, you have three options:
+
+1. Don't deploy today.
+2. Deploy files by hand using an SFTP client.
+3. Using an SFTP client, delete all `.git-ftp.log` files from the remote server.
+
+## Deploying to a site that has been edited outside of version control
+
+If the site you are deploying to has been edited outside of the version-control workflow, you have two options: ignore the changes and redeploy, or incorporate the changes into version control and then redeploy.
+
+To ignore the changes, proceed with a normal deploy as described under "Simple Deploy"
+
+To incorporate the changes:
+
+1. Using an SFTP client, copy all files from production that are relevant to this project:
+	- any file tracked in your local copy of the repository
+	- any file found in a folder the contents of which are tracked by the repository
+2. Run `git status` to see what files have changed. Use that and `git diff` to decide whether to keep or discard changes from the remote server.
+3. Commit the changes you would like to keep.
+4. Push your changes to GitHub
+5. Deploy, following the normal deploy process.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -10,13 +10,40 @@ Before running any deploy, you'll need to make sure:
 
 Here's a table of contents of this page:
 
-- Normal Deploy
+- Deploy, short version
+- Normal deploy, explained
 - Deploy a site for the first time via SFTP
 - Deploy fails with "failed to resolve ... as a valid commit"
 - Deploying to a site that has been edited outside of version control
 
 
-## Simple deploy
+## Deploy, short version
+
+Deploying staging
+
+```
+workon largo
+git checkout staging
+git pull
+git push
+fab staging branch:staging dry_run deploy
+fab staging branch:staging deploy
+```
+
+Deploying production, after merging staging into master:
+
+```
+workon largo
+git checkout master
+git pull
+git push
+fab production branch:master dry_run deploy
+fab production branch:master deploy
+```
+
+And then go clear the CDN caches.
+
+## Normal deploy, explained
 
 Let's test-deploy the 'staging' branch to the staging environment. This doesn't upload anything, but just makes sure that everything can be uploaded.
 
@@ -38,6 +65,8 @@ When it comes time to deploy to production:
 
 	fab production master dry_run deploy
 	fab production master deploy
+
+After deploying to production, be sure to clear the production CDN caches.
 
 ## Deploy a site for the first time via SFTP
 

--- a/docs/using-in-your-project.md
+++ b/docs/using-in-your-project.md
@@ -1,0 +1,52 @@
+# Setup
+
+If you're creating an INN-style umbrella repository for a Wordpress site or multisite, these tools are already included in [the umbrella boilerplate](https://github.com/INN/umbrella-boilerplate/blob/master/docs/README.md).
+
+If you're doing something else, read on.
+
+To use these tools in your project, add this repo as a git submodule in the root of your project, in the `tools` directory:
+
+	$ git submodule add https://github.com/INN/deploy-tools.git tools
+
+Then pull the example files in to the root of your project:
+
+	$ cp -Rf tools/examples/* ./
+
+Install the required libraries with pip:
+
+Note: if you're using OS X Mavericks (10.9), you might need to set some compiler flags for Fabric and its dependencies to install correctly:
+
+    $ export CFLAGS=-Qunused-arguments
+    $ export CPPFLAGS=-Qunused-arguments
+
+Then:
+
+    $ workon projectnamegoeshere
+    $ pip install -r requirements.txt
+    $ fab wp.verify_prerequisites
+
+The `wp.verify_prerequisites` command will notify you of any issues that might prevent you from using the deploy tools in their entirety.
+
+Now edit the example `fabfile.py` to adjust the settings for your project:
+
+    env.project_name = ''   # name for the project
+
+You'll also want to supply the ssh environment variables for `production` and `staging` (or any other enviornments).
+
+    env.hosts       = []    # ssh host for production.
+    env.user        = ''    # ssh user for production.
+    env.password    = ''    # ssh password for production.
+
+    env.hosts       = []    # ssh host for staging.
+    env.user        = ''    # ssh user for staging.
+    env.password    = ''    # ssh password for staging.
+
+By default, the deploy tools will use git for deployment to WP Engine. If you'd rather use sftp to deploy, you can do so by specifying `sftp_deploy` in your `fabfile.py`.
+
+    env.sftp_deploy = True
+
+After setting `env.sftp_deploy` to `True`, make sure you run `wp.verify_prerequisites` to ensure you have the required software installed.
+
+If your version of curl does not support sftp and you wish to use the tools in this repository to deploy, you will have to use a version of curl that does support it. For OSX users, the verification script uses brew to take care of that problem. For users of other operating systems, check your online support communities. Ubuntu users may have success in following [this guide](http://zeroset.mnim.org/2013/03/14/sftp-support-for-curl-in-ubuntu-12-10-quantal-quetzal-and-later/).
+
+

--- a/docs/vagrant.md
+++ b/docs/vagrant.md
@@ -1,0 +1,23 @@
+# Vagrant
+
+This repository ships with a default configuration. You do not have to use it; any repository built off of INN's [boilerplate umbrella](https://github.com/INN/umbrella-boilerplate) uses [VVV](https://github.com/Varying-Vagrant-Vagrants/VVV) with [vv](https://github.com/bradp/vv) instead.
+
+The examples directory includes a `Vagrantfile`, a bunch of config files for Apache, PHP, MySQL and a `boot-script.sh` for provisioning a Vagrant instance for local development.
+
+Assuming you have [VirtualBox](https://www.virtualbox.org/wiki/Downloads) and [Vagrant](http://www.vagrantup.com/downloads) installed, and enough spare disk space, start the Vagrant box with:
+
+    $ vagrant up
+
+It should take about ten minutes to complete the provisioning process, depending on your internet connection speed. 
+
+When the Vagrant box is ready, you'll want to edit your `/etc/hosts` file (i.e. not the `hosts` file on the Vagrant box), adding:
+
+    192.168.33.10 vagrant.dev
+
+Once you've done that, you should be able to visit [http://vagrant.dev](http://vagrant.dev) and see your project running.
+
+A couple notes:
+
+- The Apache configuration for our Vagrant box uses the root directory of your project as the www root for vagrant.dev.
+- Our provisioning script installs mysql and sets a password for the root user with value 'root'.
+


### PR DESCRIPTION
## Changes

- gut README.md, replacing gutted portions with links to new files
- make separate files in the `docs/` folder for:
    - deploying
    - setting this tool up in a new umbrella repo
    - the default standalone vagrant included in these tools as an example

## Why

To improve the deploy docs, and better organize the docs in this project in general.

Kinda addresses parts of #13; obsoletes the ['docs' branch](https://github.com/INN/deploy-tools/compare/docs).